### PR TITLE
Throughput calculation fixup

### DIFF
--- a/src/ServiceControl.Monitoring.Tests/MonitoredEndpoints/AggregatorTests.cs
+++ b/src/ServiceControl.Monitoring.Tests/MonitoredEndpoints/AggregatorTests.cs
@@ -230,7 +230,8 @@
                     {
                         new IntervalsStore.TimeInterval { IntervalStart = now, TotalValue = ridiculouslyBigLong1, TotalMeasurements = 4},
                         new IntervalsStore.TimeInterval { IntervalStart = now.AddSeconds(2), TotalValue = ridiculouslyBigLong2, TotalMeasurements = 5}
-                    }
+                    },
+                    TotalMeasurements = 4 + 5
                 },
                 new IntervalsStore.EndpointInstanceIntervals
                 {
@@ -239,7 +240,8 @@
                     {
                         new IntervalsStore.TimeInterval { IntervalStart = now, TotalValue = ridiculouslyBigLong1, TotalMeasurements = 6},
                         new IntervalsStore.TimeInterval { IntervalStart = now.AddSeconds(2), TotalValue = ridiculouslyBigLong2, TotalMeasurements = 7},
-                    }
+                    },
+                    TotalMeasurements = 6 + 7
                 }
             };
 
@@ -247,9 +249,10 @@
             var seconds = VariableHistoryIntervalStore.GetIntervalSize(period).TotalSeconds;
             var values = IntervalsAggregator.AggregateTotalMeasurementsPerSecond(intervals, period);
 
+            Assert.AreEqual((4d + 5d + 6d + 7d) / 4 / seconds, values.Average);
             Assert.AreEqual(2, values.Points.Length);
-            Assert.AreEqual((4d + 6d) / 2 / seconds, values.Points[0]);
-            Assert.AreEqual((5d + 7d) / 2 / seconds, values.Points[1]);
+            Assert.AreEqual((4d + 6d) / seconds, values.Points[0]);
+            Assert.AreEqual((5d + 7d) / seconds, values.Points[1]);
         }
 
         [Test]
@@ -290,7 +293,7 @@
 
             var values = IntervalsAggregator.AggregateTotalMeasurementsPerSecond(intervals, period);
 
-            Assert.AreEqual((7d + 9d) / 2 / seconds, values.Average);
+            Assert.AreEqual((7d + 9d) / 5 / seconds, values.Average);
         }
     }
 }

--- a/src/ServiceControl.Monitoring/Http/Diagrams/IntervalsAggregator.cs
+++ b/src/ServiceControl.Monitoring/Http/Diagrams/IntervalsAggregator.cs
@@ -59,15 +59,17 @@
 
         public static MonitoredEndpointValues AggregateTotalMeasurementsPerSecond(List<IntervalsStore.EndpointInstanceIntervals> intervals, HistoryPeriod period)
         {
+            Func<long, double> returnOneIfZero = x => x == 0 ? 1 : x;
+
             var seconds = VariableHistoryIntervalStore.GetIntervalSize(period).TotalSeconds;
 
             return new MonitoredEndpointValues
             {
-                Average = (double) intervals.Sum(t => t.TotalMeasurements) / intervals.Count / seconds,
+                Average = intervals.Sum(t => t.TotalMeasurements) / returnOneIfZero(intervals.Sum(t => t.Intervals.Length)) / seconds,
                 Points = intervals.SelectMany(t => t.Intervals)
                     .GroupBy(i => i.IntervalStart)
                     .OrderBy(g => g.Key)
-                    .Select(g => (double)g.Sum(i => i.TotalMeasurements) / g.Count() / seconds)
+                    .Select(g => g.Sum(i => i.TotalMeasurements) / seconds)
                     .ToArray()
             };
         }


### PR DESCRIPTION
Throughput should be calculated in a following way:
- Average: average over all reported intervals, 0 when no reports
- Points: should provide a summarized value per endpoint/instance

to make it `msg/s` the result value in both cases is divided by number of seconds. This makes it coheren with Retries aggregation beside the final division by seconds.