### PR TITLE
Monitoring endpoint instance activity

### DIFF
--- a/src/ServiceControl.Monitoring.Tests/Infrastructure/EndpointInstanceActivityTrackerTests.cs
+++ b/src/ServiceControl.Monitoring.Tests/Infrastructure/EndpointInstanceActivityTrackerTests.cs
@@ -1,0 +1,56 @@
+﻿namespace ServiceControl.Monitoring.Tests.Infrastructure
+{
+    using System;
+    using Monitoring.Infrastructure;
+    using NUnit.Framework;
+
+    public class EndpointInstanceActivityTrackerTests
+    {
+        EndpointInstanceActivityTracker tracker;
+        static readonly EndpointInstanceId A1 = new EndpointInstanceId("EndpointA", "instance1");
+
+        [SetUp]
+        public void Setup()
+        {
+            tracker = new EndpointInstanceActivityTracker();
+        }
+
+        [Test]
+        public void When_no_endpoint_instance_reports_not_stale()
+        {
+            Assert.IsFalse(tracker.IsStale(A1));
+        }
+
+        [Test]
+        public void When_endpoint_reported_within_staleness_period()
+        {
+            var now = DateTime.UtcNow;
+
+            tracker.Record(A1, now);
+            Assert.IsFalse(tracker.IsStale(A1));
+        }
+
+        [Test]
+        public void When_endpoint_not_reported_for_longer_than_staleness_period()
+        {
+            var now = DateTime.UtcNow
+                .Subtract(EndpointInstanceActivityTracker.StalenessThreshold)
+                .Subtract(TimeSpan.FromSeconds(1));
+
+            tracker.Record(A1, now);
+            Assert.IsTrue(tracker.IsStale(A1));
+        }
+
+        [Test]
+        public void When_endpoint_not_reported_for_longer_than_staleness_period_and_reporter_again()
+        {
+            var now = DateTime.UtcNow
+                .Subtract(EndpointInstanceActivityTracker.StalenessThreshold)
+                .Subtract(TimeSpan.FromSeconds(1));
+
+            tracker.Record(A1, now);
+            tracker.Record(A1, DateTime.UtcNow);
+            Assert.IsFalse(tracker.IsStale(A1));
+        }
+    }
+}

--- a/src/ServiceControl.Monitoring.Tests/Infrastructure/EndpointInstanceActivityTrackerTests.cs
+++ b/src/ServiceControl.Monitoring.Tests/Infrastructure/EndpointInstanceActivityTrackerTests.cs
@@ -12,7 +12,8 @@
         [SetUp]
         public void Setup()
         {
-            tracker = new EndpointInstanceActivityTracker();
+            var settings = new Settings() { EndpointUptimeGracePeriod = TimeSpan.FromMinutes(5) };
+            tracker = new EndpointInstanceActivityTracker(settings);
         }
 
         [Test]

--- a/src/ServiceControl.Monitoring.Tests/Infrastructure/EndpointInstanceActivityTrackerTests.cs
+++ b/src/ServiceControl.Monitoring.Tests/Infrastructure/EndpointInstanceActivityTrackerTests.cs
@@ -35,7 +35,7 @@
         public void When_endpoint_not_reported_for_longer_than_staleness_period()
         {
             var now = DateTime.UtcNow
-                .Subtract(EndpointInstanceActivityTracker.StalenessThreshold)
+                .Subtract(tracker.StalenessThreshold)
                 .Subtract(TimeSpan.FromSeconds(1));
 
             tracker.Record(A1, now);
@@ -46,7 +46,7 @@
         public void When_endpoint_not_reported_for_longer_than_staleness_period_and_reporter_again()
         {
             var now = DateTime.UtcNow
-                .Subtract(EndpointInstanceActivityTracker.StalenessThreshold)
+                .Subtract(tracker.StalenessThreshold)
                 .Subtract(TimeSpan.FromSeconds(1));
 
             tracker.Record(A1, now);

--- a/src/ServiceControl.Monitoring.Tests/PerformanceTests.cs
+++ b/src/ServiceControl.Monitoring.Tests/PerformanceTests.cs
@@ -35,7 +35,8 @@
             processingTimeStore = new ProcessingTimeStore();
             retriesStore = new RetriesStore();
             queueLengthStore = new QueueLengthStore(new QueueLengthCalculator());
-            activityTracker = new EndpointInstanceActivityTracker();
+            var settings = new Settings() { EndpointUptimeGracePeriod = TimeSpan.FromMinutes(5) };
+            activityTracker = new EndpointInstanceActivityTracker(settings);
 
             var monitoredEndpointsModule = new MonitoredEndpointsModule(endpointRegistry, activityTracker, criticalTimeStore, processingTimeStore, retriesStore, queueLengthStore)
             {

--- a/src/ServiceControl.Monitoring.Tests/PerformanceTests.cs
+++ b/src/ServiceControl.Monitoring.Tests/PerformanceTests.cs
@@ -25,6 +25,7 @@
         RetriesStore retriesStore;
         QueueLengthStore queueLengthStore;
         Func<Task> GetMonitoredEndpoints;
+        EndpointInstanceActivityTracker activityTracker;
 
         [SetUp]
         public void Setup()
@@ -34,10 +35,11 @@
             processingTimeStore = new ProcessingTimeStore();
             retriesStore = new RetriesStore();
             queueLengthStore = new QueueLengthStore(new QueueLengthCalculator());
+            activityTracker = new EndpointInstanceActivityTracker();
 
-            var monitoredEndpointsModule = new MonitoredEndpointsModule(endpointRegistry, criticalTimeStore, processingTimeStore, retriesStore, queueLengthStore)
+            var monitoredEndpointsModule = new MonitoredEndpointsModule(endpointRegistry, activityTracker, criticalTimeStore, processingTimeStore, retriesStore, queueLengthStore)
             {
-                Context = new NancyContext() {  Request = new Request("Get", "/monitored-endpoints", "HTTP") }
+                Context = new NancyContext() { Request = new Request("Get", "/monitored-endpoints", "HTTP") }
             };
 
             var dictionary = monitoredEndpointsModule.Routes.ToDictionary(r => r.Description.Path, r => r.Action);

--- a/src/ServiceControl.Monitoring.Tests/ServiceControl.Monitoring.Tests.csproj
+++ b/src/ServiceControl.Monitoring.Tests/ServiceControl.Monitoring.Tests.csproj
@@ -70,6 +70,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Infrastructure\EndpointInstanceActivityTrackerTests.cs" />
     <Compile Include="Infrastructure\EndpointRegistryTests.cs" />
     <Compile Include="Infrastructure\EntriesBuilder.cs" />
     <Compile Include="Infrastructure\VariableHistoryIntervalStoreTests.cs" />

--- a/src/ServiceControl.Monitoring/EndpointFactory.cs
+++ b/src/ServiceControl.Monitoring/EndpointFactory.cs
@@ -31,7 +31,7 @@
         public static void MakeMetricsReceiver(EndpointConfiguration config, Settings settings)
         {
             config.UseContainer<AutofacBuilder>(
-                c => c.ExistingLifetimeScope(CreateContainer())
+                c => c.ExistingLifetimeScope(CreateContainer(settings))
             );
 
             var selectedTransportType = DetermineTransportType(settings);
@@ -61,11 +61,12 @@
             config.EnableFeature<HttpEndpoint>();
         }
 
-        static IContainer CreateContainer()
+        static IContainer CreateContainer(Settings settings)
         {
             var containerBuilder = new ContainerBuilder();
 
             containerBuilder.RegisterModule<ApplicationModule>();
+            containerBuilder.RegisterInstance(settings).As<Settings>().SingleInstance();
 
             var container = containerBuilder.Build();
             return container;

--- a/src/ServiceControl.Monitoring/Http/Diagrams/DiagramApiModule.cs
+++ b/src/ServiceControl.Monitoring/Http/Diagrams/DiagramApiModule.cs
@@ -107,6 +107,7 @@ namespace ServiceControl.Monitoring.Http.Diagrams
                 {
                     Name = endpoint.Key,
                     EndpointInstanceIds = endpoint.Value.Select(i => i.InstanceId).ToArray(),
+                    IsStale = endpoint.Value.Any(i => activityTracker.IsStale(i))
                 }).ToArray();
         }
     }

--- a/src/ServiceControl.Monitoring/Http/Diagrams/DiagramApiModule.cs
+++ b/src/ServiceControl.Monitoring/Http/Diagrams/DiagramApiModule.cs
@@ -18,11 +18,13 @@ namespace ServiceControl.Monitoring.Http.Diagrams
         /// <summary>
         /// Initializes the metric API module.
         /// </summary>
-        public MonitoredEndpointsModule(EndpointRegistry endpointRegistry, CriticalTimeStore criticalTimeStore, ProcessingTimeStore processingTimeStore, RetriesStore retriesStore, QueueLengthStore queueLengthStore)
+        // ReSharper disable SuggestBaseTypeForParameter
+        public MonitoredEndpointsModule(EndpointRegistry endpointRegistry, EndpointInstanceActivityTracker activityTracker, CriticalTimeStore criticalTimeStore, ProcessingTimeStore processingTimeStore, RetriesStore retriesStore, QueueLengthStore queueLengthStore)
+        // ReSharper restore SuggestBaseTypeForParameter
         {
             Get["/monitored-endpoints"] = parameters =>
             {
-                var endpoints = GetMonitoredEndpoints(endpointRegistry);
+                var endpoints = GetMonitoredEndpoints(endpointRegistry, activityTracker);
                 var period = ExtractHistoryPeriod();
                
                 FillInEndpointData(endpoints, criticalTimeStore, period, (e, v) => e.CriticalTime = v, IntervalsAggregator.AggregateTimings);
@@ -38,7 +40,7 @@ namespace ServiceControl.Monitoring.Http.Diagrams
             {
                 var endpointName = (string)parameters.EndpointName;
 
-                var instances = GetMonitoredEndpointInstances(endpointRegistry, endpointName);
+                var instances = GetMonitoredEndpointInstances(endpointRegistry, endpointName, activityTracker);
                 var period = ExtractHistoryPeriod();
 
                 FillInInstanceData(instances, criticalTimeStore, period, (e, v) => e.CriticalTime = v, IntervalsAggregator.AggregateTimings);
@@ -87,23 +89,24 @@ namespace ServiceControl.Monitoring.Http.Diagrams
             }
         }
 
-        static MonitoredEndpointInstance[] GetMonitoredEndpointInstances(EndpointRegistry endpointRegistry, string endpointName)
+        static MonitoredEndpointInstance[] GetMonitoredEndpointInstances(EndpointRegistry endpointRegistry, string endpointName, EndpointInstanceActivityTracker activityTracker)
         {
             return endpointRegistry.GetEndpointInstances(endpointName)
                 .Select(endpointInstance => new MonitoredEndpointInstance
                 {
                     Id = endpointInstance.InstanceId,
-                    Name = endpointInstance.EndpointName
+                    Name = endpointInstance.EndpointName,
+                    IsStale = activityTracker.IsStale(endpointInstance)
                 }).ToArray();
         }
 
-        static MonitoredEndpoint[] GetMonitoredEndpoints(EndpointRegistry endpointRegistry)
+        static MonitoredEndpoint[] GetMonitoredEndpoints(EndpointRegistry endpointRegistry, EndpointInstanceActivityTracker activityTracker)
         {
             return endpointRegistry.GetAllEndpoints()
                 .Select(endpoint => new MonitoredEndpoint
                 {
                     Name = endpoint.Key,
-                    EndpointInstanceIds = endpoint.Value.Select(i => i.InstanceId).ToArray()
+                    EndpointInstanceIds = endpoint.Value.Select(i => i.InstanceId).ToArray(),
                 }).ToArray();
         }
     }

--- a/src/ServiceControl.Monitoring/Http/Diagrams/MonitoredEndpoint.cs
+++ b/src/ServiceControl.Monitoring/Http/Diagrams/MonitoredEndpoint.cs
@@ -3,6 +3,7 @@ namespace ServiceControl.Monitoring.Http.Diagrams
     public class MonitoredEndpoint
     {
         public string Name { get; set; }
+        public bool IsStale { get; set; }
         public string[] EndpointInstanceIds { get; set; }
         public MonitoredEndpointValues ProcessingTime { get; set; }
         public MonitoredEndpointValues CriticalTime { get; set; }

--- a/src/ServiceControl.Monitoring/Http/Diagrams/MonitoredEndpointInstance.cs
+++ b/src/ServiceControl.Monitoring/Http/Diagrams/MonitoredEndpointInstance.cs
@@ -5,10 +5,12 @@
         public string Name { get; set; }
         public string Id { get; set; }
 
+        public bool IsStale { get; set; }
+
         public MonitoredEndpointValues ProcessingTime { get; set; }
         public MonitoredEndpointValues CriticalTime { get; set; }
         public MonitoredEndpointValues Retries { get; set; }
-
+        
         // Unit: [msg/s]
         public MonitoredEndpointValues Throughput { get; set; }
     }

--- a/src/ServiceControl.Monitoring/Infrastructure/EndpointInstanceActivityTracker.cs
+++ b/src/ServiceControl.Monitoring/Infrastructure/EndpointInstanceActivityTracker.cs
@@ -1,0 +1,28 @@
+﻿namespace ServiceControl.Monitoring.Infrastructure
+{
+    using System;
+    using System.Collections.Concurrent;
+
+    public class EndpointInstanceActivityTracker
+    {
+        ConcurrentDictionary<EndpointInstanceId, DateTime> endpointsInstances = new ConcurrentDictionary<EndpointInstanceId, DateTime>();
+        public static readonly TimeSpan StalenessThreshold = TimeSpan.FromMinutes(5);
+
+        public void Record(EndpointInstanceId instanceId, DateTime utcNow)
+        {
+            endpointsInstances.AddOrUpdate(instanceId, utcNow, (_, __) => utcNow);
+        }
+
+        public bool IsStale(EndpointInstanceId endpointInstance)
+        {
+            DateTime lastActivityTime;
+            if (endpointsInstances.TryGetValue(endpointInstance, out lastActivityTime))
+            {
+                var timeSpan = DateTime.UtcNow - lastActivityTime;
+                return timeSpan > StalenessThreshold;
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/ServiceControl.Monitoring/Infrastructure/EndpointInstanceActivityTracker.cs
+++ b/src/ServiceControl.Monitoring/Infrastructure/EndpointInstanceActivityTracker.cs
@@ -6,7 +6,7 @@
     public class EndpointInstanceActivityTracker
     {
         ConcurrentDictionary<EndpointInstanceId, DateTime> endpointsInstances = new ConcurrentDictionary<EndpointInstanceId, DateTime>();
-        readonly TimeSpan StalenessThreshold;
+        internal readonly TimeSpan StalenessThreshold;
 
         public EndpointInstanceActivityTracker(Settings settings)
         {

--- a/src/ServiceControl.Monitoring/Infrastructure/EndpointInstanceActivityTracker.cs
+++ b/src/ServiceControl.Monitoring/Infrastructure/EndpointInstanceActivityTracker.cs
@@ -6,7 +6,12 @@
     public class EndpointInstanceActivityTracker
     {
         ConcurrentDictionary<EndpointInstanceId, DateTime> endpointsInstances = new ConcurrentDictionary<EndpointInstanceId, DateTime>();
-        public static readonly TimeSpan StalenessThreshold = TimeSpan.FromMinutes(5);
+        readonly TimeSpan StalenessThreshold;
+
+        public EndpointInstanceActivityTracker(Settings settings)
+        {
+            StalenessThreshold = settings.EndpointUptimeGracePeriod;
+        }
 
         public void Record(EndpointInstanceId instanceId, DateTime utcNow)
         {

--- a/src/ServiceControl.Monitoring/Infrastructure/EndpointTracker.cs
+++ b/src/ServiceControl.Monitoring/Infrastructure/EndpointTracker.cs
@@ -1,5 +1,6 @@
 ﻿namespace ServiceControl.Monitoring.Infrastructure
 {
+    using System;
     using System.Threading.Tasks;
     using Messaging;
     using NServiceBus;
@@ -7,9 +8,10 @@
 
     public class EndpointTracker : IHandleMessages<MetricReport>, IHandleMessages<LongValueOccurrences>, IHandleMessages<Occurrences>
     {
-        public EndpointTracker(EndpointRegistry endpointRegistry)
+        public EndpointTracker(EndpointRegistry endpointRegistry, EndpointInstanceActivityTracker activityTracker)
         {
             this.endpointRegistry = endpointRegistry;
+            this.activityTracker = activityTracker;
         }
 
         public Task Handle(LongValueOccurrences message, IMessageHandlerContext context)
@@ -32,10 +34,12 @@
             var instanceId = EndpointInstanceId.From(context.MessageHeaders);
 
             endpointRegistry.Record(instanceId);
+            activityTracker.Record(instanceId, DateTime.UtcNow);
 
             return TaskEx.Completed;
         }
 
         EndpointRegistry endpointRegistry;
+        readonly EndpointInstanceActivityTracker activityTracker;
     }
 }

--- a/src/ServiceControl.Monitoring/ServiceControl.Monitoring.csproj
+++ b/src/ServiceControl.Monitoring/ServiceControl.Monitoring.csproj
@@ -136,6 +136,7 @@
     <Compile Include="App_Packages\Particular.Licensing\TrialStartDateStore.cs" />
     <Compile Include="App_Packages\Particular.Licensing\UniversalDateParser.cs" />
     <Compile Include="App_Packages\Particular.Licensing\UserSidChecker.cs" />
+    <Compile Include="Infrastructure\EndpointInstanceActivityTracker.cs" />
     <Compile Include="Infrastructure\EndpointInstanceId.cs" />
     <Compile Include="Hosting\Commands\CommandRunner.cs" />
     <Compile Include="Hosting\Commands\AbstractCommand.cs" />

--- a/src/ServiceControl.Monitoring/Settings.cs
+++ b/src/ServiceControl.Monitoring/Settings.cs
@@ -4,6 +4,7 @@ namespace ServiceControl.Monitoring
     using System.Reflection;
     using NLog;
     using NServiceBus;
+    using System;
 
     public class Settings
     {
@@ -18,6 +19,7 @@ namespace ServiceControl.Monitoring
         public bool EnableInstallers { get; set; }
         public string HttpHostName { get; set; }
         public string HttpPort { get; set; }
+        public TimeSpan EndpointUptimeGracePeriod { get; set; }
 
         internal static Settings Load(SettingsReader reader)
         {
@@ -28,7 +30,8 @@ namespace ServiceControl.Monitoring
                 LogPath = reader.Read("Monitoring/LogPath", DefautLogLocation()),
                 ErrorQueue = reader.Read("Monitoring/ErrorQueue", "error"),
                 HttpHostName = reader.Read<string>("Monitoring/HttpHostname"),
-                HttpPort = reader.Read<string>("Monitoring/HttpPort")
+                HttpPort = reader.Read<string>("Monitoring/HttpPort"),
+                EndpointUptimeGracePeriod = TimeSpan.Parse(reader.Read<string>("Monitoring/EndpointUptimeGracePeriod", "00:00:40"))
             };
             return settings;
         }

--- a/src/ServiceControl.Monitoring/Settings.cs
+++ b/src/ServiceControl.Monitoring/Settings.cs
@@ -31,7 +31,7 @@ namespace ServiceControl.Monitoring
                 ErrorQueue = reader.Read("Monitoring/ErrorQueue", "error"),
                 HttpHostName = reader.Read<string>("Monitoring/HttpHostname"),
                 HttpPort = reader.Read<string>("Monitoring/HttpPort"),
-                EndpointUptimeGracePeriod = TimeSpan.Parse(reader.Read<string>("Monitoring/EndpointUptimeGracePeriod", "00:00:40"))
+                EndpointUptimeGracePeriod = TimeSpan.Parse(reader.Read("Monitoring/EndpointUptimeGracePeriod", "00:00:40"))
             };
             return settings;
         }


### PR DESCRIPTION
Connects to https://github.com/Particular/LaunchWave.DevOpsAdvancedMonitoring/issues/147

This PR introduces the monitoring of endpoints' instances' activity. 

When no message is sent for a specific period of time, an instance is considered stale and this state is reported via `MonitoredEndpointInstance.IsStale` property. 
No staleness is calculated for the `MonitoredEndpoint` as there's no single value that can describe whether or not an endpoint's data, as a whole, are stale or not.