### PR TITLE
Learning Transport Support

### DIFF
--- a/src/Packaging.NServiceBus.Learning/Packaging.NServiceBus.Learning.csproj
+++ b/src/Packaging.NServiceBus.Learning/Packaging.NServiceBus.Learning.csproj
@@ -1,0 +1,54 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <AllowedReferenceRelatedFileExtensions>.pdb</AllowedReferenceRelatedFileExtensions>
+  </PropertyGroup>
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{F30AC7F6-FD0A-43D2-BC75-889F9A7D2872}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>Packaging.NServiceBus.Learning</RootNamespace>
+    <AssemblyName>Packaging.NServiceBus.Learning</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup>
+    <StartupObject />
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\ServiceControl.LearningTransport\ServiceControl.Transports.LearningTransport.csproj">
+      <Project>{f820752b-5f01-40f1-ae26-1604f3c85f55}</Project>
+      <Name>ServiceControl.Transports.LearningTransport</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="AfterBuild">
+    <Message Text="Deleting files from output that should not be packaged" Importance="High" />
+    <ItemGroup>
+      <ExcessFiles Include="$(OutputPath)$(AssemblyName).*;$(OutputPath)NServiceBus.Core.*" />
+    </ItemGroup>
+    <Delete Files="@(ExcessFiles)" />
+  </Target>
+</Project>

--- a/src/Packaging.ServiceControl.Monitoring/Packaging.ServiceControl.Monitoring.csproj
+++ b/src/Packaging.ServiceControl.Monitoring/Packaging.ServiceControl.Monitoring.csproj
@@ -74,6 +74,7 @@
     <AddToZip IncludeMask="*.*" ZipFolder="Transports\AzureServiceBus" SourceFolder="..\Packaging.NServiceBus.AzureServiceBus\$(OutputPath)" ZipFileName="$(ZipFile)" />
     <AddToZip IncludeMask="*.*" ZipFolder="Transports\RabbitMQ" SourceFolder="..\Packaging.NServiceBus.RabbitMQ\$(OutputPath)" ZipFileName="$(ZipFile)" />
     <AddToZip IncludeMask="*.*" ZipFolder="Transports\MSMQ" SourceFolder="..\Packaging.NServiceBus.MSMQ\$(OutputPath)" ZipFileName="$(ZipFile)" />
+    <AddToZip IncludeMask="*.*" ZipFolder="Transports\Learning" SourceFolder="..\Packaging.NServiceBus.Learning\$(OutputPath)" ZipFileName="$(ZipFile)" />
     <!-- ServiceControl.Monitoring  -->
     <AddToZip IncludeMask="*.exe" ZipFolder="ServiceControl.Monitoring" SourceFolder="..\..\binaries" ZipFileName="$(ZipFile)" />
     <AddToZip IncludeMask="*.dll" ZipFolder="ServiceControl.Monitoring" SourceFolder="..\..\binaries" ZipFileName="$(ZipFile)" />

--- a/src/ServiceControl.LearningTransport/ServiceControl.Transports.LearningTransport.csproj
+++ b/src/ServiceControl.LearningTransport/ServiceControl.Transports.LearningTransport.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net452</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NServiceBus" Version="6.4.0" />
+  </ItemGroup>
+
+</Project>

--- a/src/ServiceControl.LearningTransport/ServiceControlLearningTransport.cs
+++ b/src/ServiceControl.LearningTransport/ServiceControlLearningTransport.cs
@@ -1,0 +1,22 @@
+﻿namespace NServiceBus
+{
+    using System.IO;
+    using Settings;
+    using Transport;
+
+    public class ServiceControlLearningTransport : LearningTransport
+    {
+        public override bool RequiresConnectionString => true;
+
+        public override string ExampleConnectionStringForErrorMessage => @"c:\path\containing\solution";
+
+        public override TransportInfrastructure Initialize(SettingsHolder settings, string connectionString)
+        {
+            settings.Set(StorageLocationKey, Path.Combine(connectionString, ".learningtransport"));
+
+            return base.Initialize(settings, connectionString);
+        }
+
+        public const string StorageLocationKey = "LearningTransport.StoragePath";
+    }
+}

--- a/src/ServiceControl.Monitoring.sln
+++ b/src/ServiceControl.Monitoring.sln
@@ -27,6 +27,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Packaging.ServiceControl.Mo
 		{F253D994-9321-494E-A45C-F9C6EA8947AC} = {F253D994-9321-494E-A45C-F9C6EA8947AC}
 		{8659F8A1-31BE-497B-B0A4-500B703D99AF} = {8659F8A1-31BE-497B-B0A4-500B703D99AF}
 		{F74A93BB-2B27-45D3-857F-66165DEBE383} = {F74A93BB-2B27-45D3-857F-66165DEBE383}
+		{F30AC7F6-FD0A-43D2-BC75-889F9A7D2872} = {F30AC7F6-FD0A-43D2-BC75-889F9A7D2872}
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Packaging.NServiceBus.MSMQ", "Packaging.NServiceBus.MSMQ\Packaging.NServiceBus.MSMQ.csproj", "{8659F8A1-31BE-497B-B0A4-500B703D99AF}"
@@ -34,6 +35,8 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ServiceControl.Transports.LearningTransport", "ServiceControl.LearningTransport\ServiceControl.Transports.LearningTransport.csproj", "{F820752B-5F01-40F1-AE26-1604F3C85F55}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "CustomTransportConfigurations", "CustomTransportConfigurations", "{ED6CE213-D704-4695-97AB-3E6EA4859795}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Packaging.NServiceBus.Learning", "Packaging.NServiceBus.Learning\Packaging.NServiceBus.Learning.csproj", "{F30AC7F6-FD0A-43D2-BC75-889F9A7D2872}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -81,6 +84,10 @@ Global
 		{F820752B-5F01-40F1-AE26-1604F3C85F55}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F820752B-5F01-40F1-AE26-1604F3C85F55}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F820752B-5F01-40F1-AE26-1604F3C85F55}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F30AC7F6-FD0A-43D2-BC75-889F9A7D2872}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F30AC7F6-FD0A-43D2-BC75-889F9A7D2872}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F30AC7F6-FD0A-43D2-BC75-889F9A7D2872}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F30AC7F6-FD0A-43D2-BC75-889F9A7D2872}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -93,6 +100,7 @@ Global
 		{B7A9DC11-2199-448F-A51F-049D36003176} = {AC16BCB1-A7CA-4E50-B6BD-11518421382E}
 		{8659F8A1-31BE-497B-B0A4-500B703D99AF} = {AC16BCB1-A7CA-4E50-B6BD-11518421382E}
 		{F820752B-5F01-40F1-AE26-1604F3C85F55} = {ED6CE213-D704-4695-97AB-3E6EA4859795}
+		{F30AC7F6-FD0A-43D2-BC75-889F9A7D2872} = {AC16BCB1-A7CA-4E50-B6BD-11518421382E}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {D3D78742-599D-471F-AC9B-77C0807D9515}

--- a/src/ServiceControl.Monitoring.sln
+++ b/src/ServiceControl.Monitoring.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+# Visual Studio 15
+VisualStudioVersion = 15.0.26730.16
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ServiceControl.Monitoring", "ServiceControl.Monitoring\ServiceControl.Monitoring.csproj", "{768BE338-20F1-4106-A3EB-DCE7686FCBF0}"
 EndProject
@@ -30,6 +30,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Packaging.ServiceControl.Mo
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Packaging.NServiceBus.MSMQ", "Packaging.NServiceBus.MSMQ\Packaging.NServiceBus.MSMQ.csproj", "{8659F8A1-31BE-497B-B0A4-500B703D99AF}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ServiceControl.Transports.LearningTransport", "ServiceControl.LearningTransport\ServiceControl.Transports.LearningTransport.csproj", "{F820752B-5F01-40F1-AE26-1604F3C85F55}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "CustomTransportConfigurations", "CustomTransportConfigurations", "{ED6CE213-D704-4695-97AB-3E6EA4859795}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -73,6 +77,10 @@ Global
 		{8659F8A1-31BE-497B-B0A4-500B703D99AF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8659F8A1-31BE-497B-B0A4-500B703D99AF}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8659F8A1-31BE-497B-B0A4-500B703D99AF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F820752B-5F01-40F1-AE26-1604F3C85F55}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F820752B-5F01-40F1-AE26-1604F3C85F55}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F820752B-5F01-40F1-AE26-1604F3C85F55}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F820752B-5F01-40F1-AE26-1604F3C85F55}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -84,5 +92,9 @@ Global
 		{F74A93BB-2B27-45D3-857F-66165DEBE383} = {AC16BCB1-A7CA-4E50-B6BD-11518421382E}
 		{B7A9DC11-2199-448F-A51F-049D36003176} = {AC16BCB1-A7CA-4E50-B6BD-11518421382E}
 		{8659F8A1-31BE-497B-B0A4-500B703D99AF} = {AC16BCB1-A7CA-4E50-B6BD-11518421382E}
+		{F820752B-5F01-40F1-AE26-1604F3C85F55} = {ED6CE213-D704-4695-97AB-3E6EA4859795}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {D3D78742-599D-471F-AC9B-77C0807D9515}
 	EndGlobalSection
 EndGlobal

--- a/src/ServiceControl.Monitoring/ServiceControl.Monitoring.csproj
+++ b/src/ServiceControl.Monitoring/ServiceControl.Monitoring.csproj
@@ -83,8 +83,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="NServiceBus.Core, Version=6.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
-      <HintPath>..\packages\NServiceBus.6.2.0\lib\net452\NServiceBus.Core.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\NServiceBus.6.4.0\lib\net452\NServiceBus.Core.dll</HintPath>
     </Reference>
     <Reference Include="NServiceBus.Newtonsoft.Json, Version=1.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
       <HintPath>..\packages\NServiceBus.Newtonsoft.Json.1.0.1\lib\net452\NServiceBus.Newtonsoft.Json.dll</HintPath>

--- a/src/ServiceControl.Monitoring/packages.config
+++ b/src/ServiceControl.Monitoring/packages.config
@@ -7,7 +7,7 @@
   <package id="Nancy.Hosting.Self" version="1.4.1" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
   <package id="NLog" version="4.4.9" targetFramework="net452" />
-  <package id="NServiceBus" version="6.2.0" targetFramework="net452" />
+  <package id="NServiceBus" version="6.4.0" targetFramework="net452" />
   <package id="NServiceBus.Autofac" version="6.0.1" targetFramework="net452" />
   <package id="NServiceBus.Newtonsoft.Json" version="1.0.1" targetFramework="net452" />
   <package id="NServiceBus.NLog" version="2.0.0" targetFramework="net452" />


### PR DESCRIPTION
Enables the Monitoring Instance to run against the Learning Transport. To use it, add the following to the config file:

```xml
<configuration>
  <appSettings>
    <add key="Monitoring/TransportType" value="NServiceBus.ServiceControlLearningTransport, ServiceControl.Transports.LearningTransport" />
  </appSettings>
  <connectionStrings>
    <add name="NServiceBus/Transport" connectionString="C:\Temp\LearningTransportTest" />
  </connectionStrings>
</configuration>
```

