### PR TITLE
EndpointInstanceId equality not dependent on InstanceName

### DIFF
--- a/src/ServiceControl.Monitoring.Tests/Infrastructure/EndpointRegistryTests.cs
+++ b/src/ServiceControl.Monitoring.Tests/Infrastructure/EndpointRegistryTests.cs
@@ -1,0 +1,26 @@
+﻿namespace ServiceControl.Monitoring.Tests.Infrastructure
+{
+    using System.Linq;
+    using Monitoring.Infrastructure;
+    using NUnit.Framework;
+
+    public class EndpointRegistryTests
+    {
+        [Test]
+        public void When_known_endpoint_instance_changes_name_existing_entry_is_used_and_udpated()
+        {
+            var registry = new EndpointRegistry();
+
+            var originalId = new EndpointInstanceId("LogicalName", "instance-id", "original-name");
+            var renamedId = new EndpointInstanceId(originalId.EndpointName, originalId.InstanceId, "renamed-name");
+
+            registry.Record(originalId);
+            registry.Record(renamedId);
+
+            var records = registry.GetForEndpointName(originalId.EndpointName).ToArray();
+
+            Assert.AreEqual(1, records.Length, "Existing entry should be reused");
+            Assert.AreEqual("renamed-name", records[0].InstanceName);
+        }
+    }
+}

--- a/src/ServiceControl.Monitoring.Tests/ServiceControl.Monitoring.Tests.csproj
+++ b/src/ServiceControl.Monitoring.Tests/ServiceControl.Monitoring.Tests.csproj
@@ -74,6 +74,7 @@
     <Compile Include="API\MonitoredEndpointMessageTypeParserTests.cs" />
     <Compile Include="Infrastructure\EndpointInstanceActivityTrackerTests.cs" />
     <Compile Include="Infrastructure\BreakdownRegistryTests.cs" />
+    <Compile Include="Infrastructure\EndpointRegistryTests.cs" />
     <Compile Include="Infrastructure\EntriesBuilder.cs" />
     <Compile Include="Infrastructure\VariableHistoryIntervalStoreTests.cs" />
     <Compile Include="MonitoredEndpoints\AggregatorTests.cs" />

--- a/src/ServiceControl.Monitoring/Infrastructure/EndpointInstanceId.cs
+++ b/src/ServiceControl.Monitoring/Infrastructure/EndpointInstanceId.cs
@@ -9,11 +9,9 @@
         public string InstanceId { get; }       
         public string InstanceName { get; }
 
-
         public EndpointInstanceId(string endpointName, string instanceId) 
             : this(endpointName, instanceId, instanceId)
         {
-            
         }
 
         public EndpointInstanceId(string endpointName, string instanceId, string instanceName)
@@ -26,9 +24,8 @@
         public static EndpointInstanceId From(IReadOnlyDictionary<string, string> headers)
         {
             var endpointName = headers[Headers.OriginatingEndpoint];
-            string instanceId;
 
-            if (headers.TryGetValue(MetricHeaders.MetricInstanceId, out instanceId))
+            if (headers.TryGetValue(MetricHeaders.MetricInstanceId, out var instanceId))
             {
                 return new EndpointInstanceId(endpointName, instanceId);
             }
@@ -42,8 +39,7 @@
         protected bool Equals(EndpointInstanceId other)
         {
             return string.Equals(EndpointName, other.EndpointName) && 
-                   string.Equals(InstanceId, other.InstanceId) && 
-                   string.Equals(InstanceName, other.InstanceName);
+                   string.Equals(InstanceId, other.InstanceId);
         }
 
         public override bool Equals(object obj)
@@ -61,7 +57,6 @@
             {
                 var hashCode = (EndpointName != null ? EndpointName.GetHashCode() : 0);
                 hashCode = (hashCode * 397) ^ (InstanceId != null ? InstanceId.GetHashCode() : 0);
-                hashCode = (hashCode * 397) ^ (InstanceName != null ? InstanceName.GetHashCode() : 0);
                 return hashCode;
             }
         }

--- a/src/ServiceControl.Monitoring/Infrastructure/EndpointRegistry.cs
+++ b/src/ServiceControl.Monitoring/Infrastructure/EndpointRegistry.cs
@@ -1,9 +1,25 @@
 ﻿namespace ServiceControl.Monitoring.Infrastructure
 {
+    using System.Collections.Generic;
+
     public class EndpointRegistry : BreakdownRegistry<EndpointInstanceId>
     {
         public EndpointRegistry() : base(i => i.EndpointName)
         {
+        }
+
+        protected override bool AddBreakdown(EndpointInstanceId newEndpointId, Dictionary<EndpointInstanceId, EndpointInstanceId> existingBreakdowns)
+        {
+            if(existingBreakdowns.TryGetValue(newEndpointId, out var existingInstanceId))
+            {
+                existingBreakdowns[newEndpointId] = newEndpointId;
+
+                return existingInstanceId.InstanceName != newEndpointId.InstanceName;
+            }
+
+            existingBreakdowns.Add(newEndpointId, newEndpointId);
+
+            return true;
         }
     }
 }


### PR DESCRIPTION
## Overview
This PR changes the equality relation between `EndpointInstanceId` instances. Previously it took into consideration `InstanceName` which caused faulty behavior.

In scenarios when users specified custom display names via core api:

```
  endpointConfiguration.UniquelyIdentifyRunningInstance()
                .UsingCustomIdentifier(new Guid("1C62248E-2681-45A4-B44D-5CF93584BAD6"))
                .UsingCustomDisplayName("original-instance-rename");
```

and changed `DisplayName` during instance lifetime (keeping `CustomIndentifier` same) they would end up with two entries representing same endpoint instance (for the old name and the new one).

/cc: @Scooletz thx for help!