### PR TITLE
SQL Native Queue Length

### DIFF
--- a/src/ServiceControl.Monitoring.SmokeTests.SQLServer/ServiceControl.Monitoring.SmokeTests.SQLServer.csproj
+++ b/src/ServiceControl.Monitoring.SmokeTests.SQLServer/ServiceControl.Monitoring.SmokeTests.SQLServer.csproj
@@ -43,7 +43,7 @@
       <HintPath>..\packages\NServiceBus.Metrics.2.0.0\lib\net452\NServiceBus.Metrics.dll</HintPath>
     </Reference>
     <Reference Include="NServiceBus.Metrics.ServiceControl, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\NServiceBus.Metrics.ServiceControl.2.0.0\lib\net452\NServiceBus.Metrics.ServiceControl.dll</HintPath>
+      <HintPath>..\packages\NServiceBus.Metrics.ServiceControl.2.1.0-rc0002\lib\net452\NServiceBus.Metrics.ServiceControl.dll</HintPath>
     </Reference>
     <Reference Include="NServiceBus.Transport.SqlServer, Version=3.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
       <HintPath>..\packages\NServiceBus.SqlServer.3.1.2\lib\net452\NServiceBus.Transport.SqlServer.dll</HintPath>
@@ -78,6 +78,7 @@
     <Compile Include="NServiceBusAcceptanceTest.cs" />
     <Compile Include="ScenarioDescriptors\EnvironmentHelper.cs" />
     <Compile Include="Tests\ApiIntegrationTest.cs" />
+    <Compile Include="Tests\When_querying_queue_length.cs" />
     <Compile Include="Tests\When_querying_retries_data.cs" />
     <Compile Include="Tests\When_querying_timings_data.cs" />
     <Compile Include="Tests\When_running_on_custom_schema.cs" />

--- a/src/ServiceControl.Monitoring.SmokeTests.SQLServer/ServiceControl.Monitoring.SmokeTests.SQLServer.csproj
+++ b/src/ServiceControl.Monitoring.SmokeTests.SQLServer/ServiceControl.Monitoring.SmokeTests.SQLServer.csproj
@@ -78,6 +78,7 @@
     <Compile Include="NServiceBusAcceptanceTest.cs" />
     <Compile Include="ScenarioDescriptors\EnvironmentHelper.cs" />
     <Compile Include="Tests\ApiIntegrationTest.cs" />
+    <Compile Include="Tests\SqNameHelperTests.cs" />
     <Compile Include="Tests\When_querying_queue_length.cs" />
     <Compile Include="Tests\When_querying_retries_data.cs" />
     <Compile Include="Tests\When_querying_timings_data.cs" />

--- a/src/ServiceControl.Monitoring.SmokeTests.SQLServer/Tests/SqNameHelperTests.cs
+++ b/src/ServiceControl.Monitoring.SmokeTests.SQLServer/Tests/SqNameHelperTests.cs
@@ -1,0 +1,35 @@
+﻿namespace ServiceControl.Monitoring.SmokeTests.SQS.Tests
+{
+    using NUnit.Framework;
+    using Transports.SQLServer;
+
+    public class SqlNameHelperTests
+    {
+        [TestCase("[quoted]")]
+        [TestCase("[quote]]d]")]
+        public void Quoted_names_does_not_change(string name)
+        {
+            var quotedName = SqlNameHelper.Quote(name);
+
+            Assert.AreEqual(name, quotedName);
+        }
+
+        [TestCase("adfasfd", "[adfasfd]")]
+        [TestCase("ad[fasfd]", "[ad[fasfd]]]")]
+        public void Unquoted_name_by_appending_brackets_and_escaping_right_content_brackest(string name, string expectedQuotedName)
+        {
+            var quotedName = SqlNameHelper.Quote(name);
+
+            Assert.AreEqual(expectedQuotedName, quotedName);
+        }
+
+        [Test]
+        public void Quoted_name_is_unchanged_after_quoting()
+        {
+            var quotedName = "[name]";
+            var afterQuoting = SqlNameHelper.Quote(quotedName);
+
+            Assert.AreEqual(quotedName, afterQuoting);
+        }
+    }
+}

--- a/src/ServiceControl.Monitoring.SmokeTests.SQLServer/Tests/When_querying_queue_length.cs
+++ b/src/ServiceControl.Monitoring.SmokeTests.SQLServer/Tests/When_querying_queue_length.cs
@@ -1,0 +1,89 @@
+﻿namespace ServiceControl.Monitoring.SmokeTests.ASQ.Tests
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using EndpointTemplates;
+    using Newtonsoft.Json.Linq;
+    using NServiceBus;
+    using NServiceBus.AcceptanceTesting;
+    using NUnit.Framework;
+    using Conventions = NServiceBus.AcceptanceTesting.Customization.Conventions;
+
+    [Category("TransportSmokeTests")]
+    public class When_querying_queue_length : ApiIntegrationTest
+    {
+        static string MonitoringEndpointName => Conventions.EndpointNamingConvention(typeof(MonitoringEndpoint));
+
+        [Test]
+        public async Task Should_report_via_http()
+        {
+            JToken retries = null;
+
+            await Scenario.Define<QueueLengthContext>()
+                .WithEndpoint<SendingEndpoint>(c =>
+                {
+                    c.CustomConfig(ec => ec.LimitMessageProcessingConcurrencyTo(1));
+                    c.DoNotFailOnErrorMessages();
+                    c.When(async s =>
+                    {
+                        await s.SendLocal(new SampleMessage());
+                        await s.SendLocal(new SampleMessage());
+                        await s.SendLocal(new SampleMessage());
+                    });
+                })
+                .WithEndpoint<MonitoringEndpoint>()
+                .Done(c =>
+                {
+                    var done = MetricReported("queueLength", out retries, c);
+
+                    if (done) { c.CancelProcessingTokenSource.Cancel();}
+
+                    return done;
+                })
+                .Run();
+
+            Assert.IsTrue(retries["average"].Value<double>() > 0);
+            Assert.AreEqual(60, retries["points"].Value<JArray>().Count);
+        }
+
+        class SendingEndpoint : EndpointConfigurationBuilder
+        {
+            public SendingEndpoint()
+            {
+                EndpointSetup<DefaultServer>(c =>
+                {
+                    c.EnableMetrics().SendMetricDataToServiceControl(MonitoringEndpointName, TimeSpan.FromSeconds(1));
+                });
+            }
+
+            class Handler : IHandleMessages<SampleMessage>
+            {
+                public QueueLengthContext Context { get; set; }
+
+                public Task Handle(SampleMessage message, IMessageHandlerContext context)
+                {
+                    //Concurrency limit 1 and this should block any processing on input queue
+                    return Task.Delay(TimeSpan.FromDays(1), Context.CancelProcessingTokenSource.Token);
+                }
+            }
+        }
+
+        class MonitoringEndpoint : EndpointConfigurationBuilder
+        {
+            public MonitoringEndpoint()
+            {
+                EndpointSetup<DefaultServer>(c =>
+                {
+                    EndpointFactory.MakeMetricsReceiver(c, Settings, ConfigureEndpointSqlServerTransport.ConnectionString);
+                    c.LimitMessageProcessingConcurrencyTo(1);
+                });
+            }
+        }
+
+        class QueueLengthContext : Context
+        {
+            public CancellationTokenSource CancelProcessingTokenSource = new CancellationTokenSource();
+        }
+    }
+}

--- a/src/ServiceControl.Monitoring.SmokeTests.SQLServer/packages.config
+++ b/src/ServiceControl.Monitoring.SmokeTests.SQLServer/packages.config
@@ -4,7 +4,7 @@
   <package id="NServiceBus" version="6.3.4" targetFramework="net46" />
   <package id="NServiceBus.AcceptanceTesting" version="6.2.0" targetFramework="net46" />
   <package id="NServiceBus.Metrics" version="2.0.0" targetFramework="net46" />
-  <package id="NServiceBus.Metrics.ServiceControl" version="2.0.0" targetFramework="net46" />
+  <package id="NServiceBus.Metrics.ServiceControl" version="2.1.0-rc0002" targetFramework="net46" />
   <package id="NServiceBus.SqlServer" version="3.1.2" targetFramework="net46" />
   <package id="NUnit" version="3.7.1" targetFramework="net46" />
 </packages>

--- a/src/ServiceControl.Monitoring.SmokeTests.SQS/ServiceControl.Monitoring.SmokeTests.SQS.csproj
+++ b/src/ServiceControl.Monitoring.SmokeTests.SQS/ServiceControl.Monitoring.SmokeTests.SQS.csproj
@@ -101,5 +101,8 @@
     <Analyzer Include="..\packages\AWSSDK.S3.3.3.16.2\analyzers\dotnet\cs\AWSSDK.S3.CodeAnalysis.dll" />
     <Analyzer Include="..\packages\AWSSDK.SQS.3.3.3.2\analyzers\dotnet\cs\AWSSDK.SQS.CodeAnalysis.dll" />
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/src/ServiceControl.Transports.SQLServer/InternalsVisibleTo.cs
+++ b/src/ServiceControl.Transports.SQLServer/InternalsVisibleTo.cs
@@ -1,0 +1,3 @@
+﻿using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("ServiceControl.Monitoring.SmokeTests.SQLServer")]

--- a/src/ServiceControl.Transports.SQLServer/QueueLengthProvider.cs
+++ b/src/ServiceControl.Transports.SQLServer/QueueLengthProvider.cs
@@ -1,0 +1,193 @@
+﻿namespace ServiceControl.Transports.SQLServer
+{
+	using System;
+	using System.Collections.Concurrent;
+	using System.Collections.Generic;
+	using System.Data.SqlClient;
+	using System.Linq;
+	using System.Threading;
+	using System.Threading.Tasks;
+	using Monitoring;
+	using Monitoring.Infrastructure;
+	using Monitoring.Messaging;
+	using Monitoring.QueueLength;
+	using NServiceBus.Logging;
+	using NServiceBus.Metrics;
+
+	public class QueueLengthProvider : IProvideQueueLength
+	{
+		ConcurrentDictionary<EndpointInputQueue, SqlTable> endpointInputQueueToTableName = new ConcurrentDictionary<EndpointInputQueue, SqlTable>();
+		ConcurrentDictionary<SqlTable, int> tableSizes = new ConcurrentDictionary<SqlTable, int>();
+
+		string connectionString;
+		QueueLengthStore store;
+
+		CancellationTokenSource stop = new CancellationTokenSource();
+		Task pooler;
+
+		public void Initialize(string connectionString, QueueLengthStore store)
+		{
+			this.connectionString = connectionString;
+			this.store = store;
+		}
+
+		public void Process(EndpointInstanceId endpointInstanceId, EndpointMetadataReport metadataReport)
+		{
+			var endpointInputQueue = new EndpointInputQueue(endpointInstanceId.EndpointName, metadataReport.LocalAddress);
+			var localAddress = metadataReport.LocalAddress;
+			var pluginVersion = metadataReport.PluginVersion;
+
+			if (SqlTable.TryParse(localAddress, pluginVersion, out var sqlTable))
+			{
+			    SqlTable previousSqlTable = null;
+
+				endpointInputQueueToTableName.AddOrUpdate(endpointInputQueue, _ => sqlTable, (_, cv) =>
+				{
+					previousSqlTable = cv;
+					return sqlTable;
+				});
+
+			    if (previousSqlTable == null)
+			    {
+			        tableSizes.TryAdd(sqlTable, 0);
+                }
+				else if (previousSqlTable.Equals(sqlTable) == false)
+				{
+					tableSizes.TryRemove(previousSqlTable, out var _);
+					tableSizes.TryAdd(sqlTable, 0);
+				}
+			}
+			else
+			{
+				Logger.Warn($"Could not localAddress {localAddress}. Sent by {endpointInstanceId.EndpointName} id {endpointInstanceId.InstanceId}. Plugin version {pluginVersion}");
+			}
+		}
+
+		public void Process(EndpointInstanceId endpointInstanceId, TaggedLongValueOccurrence metricsReport)
+		{
+			//HINT: Sql server endpoints do not support endpoint level queue length monitoring
+		}
+	   
+		public Task Start()
+		{
+			stop = new CancellationTokenSource();
+
+			pooler = Task.Run(async () =>
+			{
+				while (!stop.Token.IsCancellationRequested)
+				{
+					try
+					{
+						await QueryTableSizes();
+
+						UpdateQueueLengthStore();
+
+						await Task.Delay(QueryDelayInterval);
+					}
+					catch (Exception e)
+					{
+						Logger.Error("Error querying sql queue sizes.", e);
+					}
+				}
+			});
+
+			return TaskEx.Completed;
+		}
+
+	    public Task Stop()
+	    {
+	        stop.Cancel();
+
+	        return pooler;
+	    }
+
+        void UpdateQueueLengthStore()
+		{
+			var nowTicks = DateTime.UtcNow.Ticks;
+
+			foreach (var endpointToTableNamePair in endpointInputQueueToTableName)
+			{
+				store.Store(
+					new []{ new RawMessage.Entry
+					{
+						DateTicks = nowTicks,
+						Value = tableSizes.TryGetValue(endpointToTableNamePair.Value, out var size) ? size : 0
+					}}, 
+					endpointToTableNamePair.Key);
+			}
+		}
+
+		async Task QueryTableSizes()
+		{
+			var chunks = tableSizes
+				.Select((i, index) => new
+				{
+					i,
+					index
+				})
+				.GroupBy(p => p.index / QueryChunkSize)
+				.Select(grp => grp.Select(g => g.i).ToArray())
+				.ToList();
+
+			foreach (var chunk in chunks)
+			{
+				using (var connection = new SqlConnection(connectionString))
+				{
+					await connection.OpenAsync();
+
+					await UpdateChunk(connection, chunk, stop.Token);
+				}
+			}
+		}
+
+		async Task UpdateChunk(SqlConnection connection, KeyValuePair<SqlTable, int>[] chunk, CancellationToken token)
+		{
+			var query = string.Join(Environment.NewLine, chunk.Select(c => BuildQueueLengthQuery(c.Key)).ToArray());
+
+			using (var command = new SqlCommand(query, connection))
+			{
+				var reader = await command.ExecuteReaderAsync(token);
+
+				foreach (var chunkPair in chunk)
+				{
+					await reader.ReadAsync(token);
+
+				    var queueLength = reader.GetInt32(0);
+
+					if (queueLength == -1)
+					{
+						Logger.Warn($"Table {chunkPair.Key} does not exist.");
+					}
+					else
+					{
+						tableSizes.TryUpdate(chunkPair.Key, queueLength, chunkPair.Value);
+					}
+
+				    await reader.NextResultAsync(token);
+				}
+			}
+		}
+
+	    static string BuildQueueLengthQuery(SqlTable t)
+	    {
+	        if (t.QuotedCatalog == null)
+	        {
+	            return $@"IF (EXISTS (SELECT *  FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = '{t.UnquotedSchema}' AND  TABLE_NAME = '{t.UnquotedName}'))
+					        SELECT count(*) FROM {t.QuotedSchema}.{t.QuotedName} WITH (nolock)
+				          ELSE
+					        SELECT -1;";
+	        }
+
+	        return $@"IF (EXISTS (SELECT *  FROM {t.QuotedCatalog}.INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = '{t.UnquotedSchema}' AND  TABLE_NAME = '{t.UnquotedName}'))
+					    SELECT count(*) FROM {t.QuotedCatalog}.{t.QuotedSchema}.{t.QuotedName} WITH (nolock)
+				      ELSE
+					    SELECT -1;";
+	    }
+
+        static TimeSpan QueryDelayInterval = TimeSpan.FromMilliseconds(200);
+
+		const int QueryChunkSize = 10;
+
+		static ILog Logger = LogManager.GetLogger<QueueLengthProvider>();
+	}
+}

--- a/src/ServiceControl.Transports.SQLServer/ServiceControl.Transports.SQLServer.csproj
+++ b/src/ServiceControl.Transports.SQLServer/ServiceControl.Transports.SQLServer.csproj
@@ -46,8 +46,10 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="InternalsVisibleTo.cs" />
     <Compile Include="QueueLengthProvider.cs" />
     <Compile Include="ServiceControlSQLServerTransport.cs" />
+    <Compile Include="SqlNameHelper.cs" />
     <Compile Include="SqlTable.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/ServiceControl.Transports.SQLServer/ServiceControl.Transports.SQLServer.csproj
+++ b/src/ServiceControl.Transports.SQLServer/ServiceControl.Transports.SQLServer.csproj
@@ -46,7 +46,9 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="QueueLengthProvider.cs" />
     <Compile Include="ServiceControlSQLServerTransport.cs" />
+    <Compile Include="SqlTable.cs" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.SqlServer">
@@ -55,6 +57,12 @@
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Properties\" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\ServiceControl.Monitoring\ServiceControl.Monitoring.csproj">
+      <Project>{768be338-20f1-4106-a3eb-dce7686fcbf0}</Project>
+      <Name>ServiceControl.Monitoring</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/src/ServiceControl.Transports.SQLServer/SqlNameHelper.cs
+++ b/src/ServiceControl.Transports.SQLServer/SqlNameHelper.cs
@@ -1,0 +1,39 @@
+﻿namespace ServiceControl.Transports.SQLServer
+{
+    class SqlNameHelper
+    {
+        const string prefix = "[";
+        const string suffix = "]";
+
+        public static string Quote(string name)
+        {
+            if (name == null)
+            {
+                return null;
+            }
+
+            if (name.StartsWith(prefix) && name.EndsWith(suffix))
+            {
+                return name;
+            }
+
+            return prefix + name.Replace(suffix, suffix + suffix) + suffix;
+        }
+
+        public static string Unquote(string quotedString)
+        {
+            if (quotedString == null)
+            {
+                return null;
+            }
+
+            if (!quotedString.StartsWith(prefix) || !quotedString.EndsWith(suffix))
+            {
+                return quotedString;
+            }
+
+            return quotedString
+                .Substring(prefix.Length, quotedString.Length - prefix.Length - suffix.Length).Replace(suffix + suffix, suffix);
+        }
+    }
+}

--- a/src/ServiceControl.Transports.SQLServer/SqlTable.cs
+++ b/src/ServiceControl.Transports.SQLServer/SqlTable.cs
@@ -1,0 +1,115 @@
+﻿namespace ServiceControl.Transports.SQLServer
+{
+    using System;
+    using System.Linq;
+
+    class SqlTable
+    {
+        SqlTable(string name, string schema, string catalog)
+        {
+            QuotedName = SqlNameHelper.Quote(name);
+            QuotedSchema = SqlNameHelper.Quote(schema);
+            QuotedCatalog = SqlNameHelper.Quote(catalog);
+        }
+
+        public string QuotedName { get; }
+        public string UnquotedName => SqlNameHelper.Unquote(QuotedName);
+
+        public string QuotedSchema { get; }
+        public string UnquotedSchema => SqlNameHelper.Unquote(QuotedSchema);
+
+        public string QuotedCatalog { get; }
+        public string UnquotedCatalog => SqlNameHelper.Unquote(QuotedCatalog);
+
+        public override string ToString()
+        {
+            return QuotedCatalog != null ? $"{QuotedCatalog}.{QuotedSchema}.{QuotedName}" : $"{QuotedSchema}.{QuotedName}";
+        }
+
+        public static bool TryParse(string address, int pluginVersion, out SqlTable sqlTable)
+        {
+            if (pluginVersion == 1)
+            {
+                sqlTable = new SqlTable(address.Split('@')[0], "dbo", null);
+                return true;
+            }
+
+            if (pluginVersion == 2)
+            {
+                var parts = address.Split('@').ToArray();
+
+                if (!parts[0].StartsWith("[") || !parts[0].EndsWith("]"))
+                {
+                    parts[0] = $"[{parts[0]}]";
+                }
+
+                sqlTable = new SqlTable(parts[0], parts[1], parts[2]);
+                return true;
+            }
+
+            sqlTable = null;
+            return false;
+        }
+
+        protected bool Equals(SqlTable other)
+        {
+            return String.Equals(QuotedName, other.QuotedName) && String.Equals(QuotedSchema, other.QuotedSchema) && String.Equals(QuotedCatalog, other.QuotedCatalog);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != this.GetType()) return false;
+            return Equals((SqlTable) obj);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                var hashCode = (QuotedName != null ? QuotedName.GetHashCode() : 0);
+                hashCode = (hashCode * 397) ^ (QuotedSchema != null ? QuotedSchema.GetHashCode() : 0);
+                hashCode = (hashCode * 397) ^ (QuotedCatalog != null ? QuotedCatalog.GetHashCode() : 0);
+                return hashCode;
+            }
+        }
+
+        class SqlNameHelper
+        {
+            const string prefix = "[";
+            const string suffix = "]";
+
+            public static string Quote(string name)
+            {
+                if (name == null)
+                {
+                    return null;
+                }
+
+                if (name.StartsWith(prefix) && name.EndsWith(suffix))
+                {
+                    return name;
+                }
+
+                return prefix + name.Replace(suffix, suffix + suffix) + suffix;
+            }
+
+            public static string Unquote(string quotedString)
+            {
+                if (quotedString == null)
+                {
+                    return null;
+                }
+
+                if (!quotedString.StartsWith(prefix) || !quotedString.EndsWith(suffix))
+                {
+                    return quotedString;
+                }
+
+                return quotedString
+                    .Substring(prefix.Length, quotedString.Length - prefix.Length - suffix.Length).Replace(suffix + suffix, suffix);
+            }
+        }
+    }
+}

--- a/src/ServiceControl.Transports.SQLServer/SqlTable.cs
+++ b/src/ServiceControl.Transports.SQLServer/SqlTable.cs
@@ -28,21 +28,16 @@
 
         public static bool TryParse(string address, int pluginVersion, out SqlTable sqlTable)
         {
+            var parts = address.Split('@').ToArray();
+
             if (pluginVersion == 1)
             {
-                sqlTable = new SqlTable(address.Split('@')[0], "dbo", null);
+                sqlTable = new SqlTable(parts[0], "dbo", null);
                 return true;
             }
 
             if (pluginVersion == 2)
             {
-                var parts = address.Split('@').ToArray();
-
-                if (!parts[0].StartsWith("[") || !parts[0].EndsWith("]"))
-                {
-                    parts[0] = $"[{parts[0]}]";
-                }
-
                 sqlTable = new SqlTable(parts[0], parts[1], parts[2]);
                 return true;
             }

--- a/src/ServiceControl.Transports.SQLServer/SqlTable.cs
+++ b/src/ServiceControl.Transports.SQLServer/SqlTable.cs
@@ -74,42 +74,5 @@
                 return hashCode;
             }
         }
-
-        class SqlNameHelper
-        {
-            const string prefix = "[";
-            const string suffix = "]";
-
-            public static string Quote(string name)
-            {
-                if (name == null)
-                {
-                    return null;
-                }
-
-                if (name.StartsWith(prefix) && name.EndsWith(suffix))
-                {
-                    return name;
-                }
-
-                return prefix + name.Replace(suffix, suffix + suffix) + suffix;
-            }
-
-            public static string Unquote(string quotedString)
-            {
-                if (quotedString == null)
-                {
-                    return null;
-                }
-
-                if (!quotedString.StartsWith(prefix) || !quotedString.EndsWith(suffix))
-                {
-                    return quotedString;
-                }
-
-                return quotedString
-                    .Substring(prefix.Length, quotedString.Length - prefix.Length - suffix.Length).Replace(suffix + suffix, suffix);
-            }
-        }
     }
 }


### PR DESCRIPTION
All the bits of #118 that ARE related to SQL

Depends on #121 

Provides an implementation of Queue Length Provider specific to the SQL transport. Accepts endpoint metadata reports and uses them to map endpoint->tables. Regularly monitors the lengths of tables and updates the Queue Length Store appropriately.