### PR TITLE
Legacy queue length logger fix

### DIFF
--- a/src/ServiceControl.Monitoring/QueueLength/LegacyQueueLengthReportHandler.cs
+++ b/src/ServiceControl.Monitoring/QueueLength/LegacyQueueLengthReportHandler.cs
@@ -1,5 +1,6 @@
 ﻿namespace ServiceControl.Monitoring.QueueLength
 {
+    using System;
     using System.Collections.Concurrent;
     using System.Threading.Tasks;
     using Infrastructure;
@@ -30,13 +31,24 @@
 
         public class LegacyQueueLengthEndpoints
         {
+            static TimeSpan cleanInterval = TimeSpan.FromHours(1);
+
             ConcurrentDictionary<string, string> regsteredInstances = new ConcurrentDictionary<string, string>();
+            DateTime lastCleanTime = DateTime.UtcNow;
 
             public bool TryAdd(string id)
             {
+                var now = DateTime.UtcNow;
+
+                if (lastCleanTime.Add(cleanInterval) < now)
+                {
+                    lastCleanTime = now;
+                    
+                    regsteredInstances.Clear();
+                }
+
                 return regsteredInstances.TryAdd(id, id);
             }
-
         }
 
         static readonly ILog Logger = LogManager.GetLogger(typeof(LegacyQueueLengthReportHandler));

--- a/src/ServiceControl.Monitoring/QueueLength/LegacyQueueLengthReportHandler.cs
+++ b/src/ServiceControl.Monitoring/QueueLength/LegacyQueueLengthReportHandler.cs
@@ -9,18 +9,34 @@
 
     class LegacyQueueLengthReportHandler : IHandleMessages<MetricReport>
     {
-        ConcurrentDictionary<string, string> loggedInstances = new ConcurrentDictionary<string, string>();
+        LegacyQueueLengthEndpoints legacyEndpoints;
+
+        public LegacyQueueLengthReportHandler(LegacyQueueLengthEndpoints legacyEndpoints)
+        {
+            this.legacyEndpoints = legacyEndpoints;
+        }
 
         public Task Handle(MetricReport message, IMessageHandlerContext context)
         {
             var endpointInstanceId = EndpointInstanceId.From(context.MessageHeaders);
 
-            if (loggedInstances.TryAdd(endpointInstanceId.InstanceId, endpointInstanceId.InstanceId))
+            if (legacyEndpoints.TryAdd(endpointInstanceId.InstanceId))
             {
                 Logger.Warn($"Legacy queue length report received from {endpointInstanceId.InstanceName} instance of {endpointInstanceId.EndpointName}");
             }
 
             return TaskEx.Completed;
+        }
+
+        public class LegacyQueueLengthEndpoints
+        {
+            ConcurrentDictionary<string, string> regsteredInstances = new ConcurrentDictionary<string, string>();
+
+            public bool TryAdd(string id)
+            {
+                return regsteredInstances.TryAdd(id, id);
+            }
+
         }
 
         static readonly ILog Logger = LogManager.GetLogger(typeof(LegacyQueueLengthReportHandler));

--- a/src/ServiceControl.Monitoring/QueueLength/LegacyQueueLengthReportHandler.cs
+++ b/src/ServiceControl.Monitoring/QueueLength/LegacyQueueLengthReportHandler.cs
@@ -41,7 +41,7 @@
             {
                 var nowTicks = DateTime.UtcNow.Ticks;
 
-                if (lastCleanTicks + cleanIntervalTicks < nowTicks)
+                if (Volatile.Read(ref lastCleanTicks) + cleanIntervalTicks < nowTicks)
                 {
                     Interlocked.Exchange(ref lastCleanTicks, nowTicks);
                     


### PR DESCRIPTION
## Overview
This PR fixes warn logging for the legacy queue length reports. It's supposed to log a warn once per endpoint `instanceId`. The implementation was based however on a dictionary that had per handler lifetime scope resulting in no de-duplication being done.

The fix proposed is to have a singleton of dedicated type that holds the reported legacy endpoints.