### PR TITLE
Queue length recordings return whole numbers

### DIFF
--- a/src/ServiceControl.Monitoring.Tests/MonitoredEndpoints/QueueLengthAggregationTests.cs
+++ b/src/ServiceControl.Monitoring.Tests/MonitoredEndpoints/QueueLengthAggregationTests.cs
@@ -36,10 +36,10 @@
                 }
             };
 
-            var values = Aggregator.ToSumOfBreakdownAverages(intervals, HistoryPeriod.FromMinutes(5));
+            var values = Aggregator.ToRoundedSumOfBreakdownAverages(intervals, HistoryPeriod.FromMinutes(5));
 
-            Assert.AreEqual(3d / 4d + 5d / 6d, values.Points[0]);
-            Assert.AreEqual(2d / 3d, values.Points[1]);
+            Assert.AreEqual(Math.Round(3d / 4d + 5d / 6d), values.Points[0]);
+            Assert.AreEqual(Math.Round(2d / 3d), values.Points[1]);
         }
 
         [Test]
@@ -63,9 +63,9 @@
                 }
             };
 
-            var values = Aggregator.ToSumOfBreakdownAverages(intervals, HistoryPeriod.FromMinutes(5));
+            var values = Aggregator.ToRoundedSumOfBreakdownAverages(intervals, HistoryPeriod.FromMinutes(5));
 
-            Assert.AreEqual(3d / 1d + 41d / 5d, values.Average);
+            Assert.AreEqual(Math.Round(3d / 1d + 41d / 5d), values.Average);
         }
 
         [Test]
@@ -94,7 +94,7 @@
                 }
             };
 
-            var values = Aggregator.ToSumOfBreakdownAverages(intervals, HistoryPeriod.FromMinutes(5));
+            var values = Aggregator.ToRoundedSumOfBreakdownAverages(intervals, HistoryPeriod.FromMinutes(5));
 
             Assert.AreEqual(3, values.Points.Length);
         }

--- a/src/ServiceControl.Monitoring/Http/Diagrams/Aggregator.cs
+++ b/src/ServiceControl.Monitoring/Http/Diagrams/Aggregator.cs
@@ -22,17 +22,17 @@
             };
         }
 
-        internal static MonitoredValues ToSumOfBreakdownAverages<T>(List<IntervalsStore<T>.IntervalsBreakdown> intervals, HistoryPeriod period)
+        internal static MonitoredValues ToRoundedSumOfBreakdownAverages<T>(List<IntervalsStore<T>.IntervalsBreakdown> intervals, HistoryPeriod period)
         {
             Func<long, double> returnOneIfZero = x => x == 0 ? 1 : x;
 
             return new MonitoredValues
             {
-                Average = intervals.Sum(t => t.TotalValue / returnOneIfZero(t.TotalMeasurements)),
+                Average = Math.Round(intervals.Sum(t => t.TotalValue / returnOneIfZero(t.TotalMeasurements))),
                 Points = intervals.SelectMany(x => x.Intervals)
                     .GroupBy(i => i.IntervalStart)
                     .OrderBy(g => g.Key)
-                    .Select(gg => gg.Sum(t => t.TotalValue / returnOneIfZero(t.TotalMeasurements)))
+                    .Select(gg => Math.Round(gg.Sum(t => t.TotalValue / returnOneIfZero(t.TotalMeasurements))))
                     .ToArray()
             };
         }

--- a/src/ServiceControl.Monitoring/Http/Diagrams/DiagramApiModule.cs
+++ b/src/ServiceControl.Monitoring/Http/Diagrams/DiagramApiModule.cs
@@ -34,7 +34,7 @@ namespace ServiceControl.Monitoring.Http.Diagrams
 
             var queueMetrics = new[]
             {
-                CreateMetric<EndpointInputQueue, QueueLengthStore>("QueueLength", Aggregator.ToSumOfBreakdownAverages)
+                CreateMetric<EndpointInputQueue, QueueLengthStore>("QueueLength", Aggregator.ToRoundedSumOfBreakdownAverages)
             };
 
             var messageTypeMetrics = new[]


### PR DESCRIPTION
This PR changes the aggregation function used by the queue length queries. It rounds the values to nearest integers so that queue length value returned to the clients are always whole numbers.