### PR TITLE
Sql native queue length provider does not support nsb.metrics.sc

### DIFF
--- a/src/ServiceControl.Transports.SQLServer/SqlTable.cs
+++ b/src/ServiceControl.Transports.SQLServer/SqlTable.cs
@@ -36,7 +36,7 @@
                 return true;
             }
 
-            if (pluginVersion == 2)
+            if (pluginVersion == 2 || pluginVersion == 3)
             {
                 sqlTable = new SqlTable(parts[0], parts[1], parts[2]);
                 return true;


### PR DESCRIPTION
## Overview
This PR adds support for parsing sql transport addresses sent from nsb.metrics.sc 3.*.