### PR TITLE
Queue Length metric does not work for SqlTransport endpoints [3.0-3.1.1)

### DIFF
--- a/src/ServiceControl.Monitoring.SmokeTests.SQLServer/ServiceControl.Monitoring.SmokeTests.SQLServer.csproj
+++ b/src/ServiceControl.Monitoring.SmokeTests.SQLServer/ServiceControl.Monitoring.SmokeTests.SQLServer.csproj
@@ -78,6 +78,7 @@
     <Compile Include="NServiceBusAcceptanceTest.cs" />
     <Compile Include="ScenarioDescriptors\EnvironmentHelper.cs" />
     <Compile Include="Tests\ApiIntegrationTest.cs" />
+    <Compile Include="Tests\SqlTableTests.cs" />
     <Compile Include="Tests\SqNameHelperTests.cs" />
     <Compile Include="Tests\When_querying_queue_length.cs" />
     <Compile Include="Tests\When_querying_retries_data.cs" />

--- a/src/ServiceControl.Monitoring.SmokeTests.SQLServer/Tests/SqlTableTests.cs
+++ b/src/ServiceControl.Monitoring.SmokeTests.SQLServer/Tests/SqlTableTests.cs
@@ -1,0 +1,38 @@
+﻿namespace ServiceControl.Monitoring.SmokeTests.SQLServer.Tests
+{
+    using NUnit.Framework;
+    using Transports.SQLServer;
+
+    public class SqlTableTests
+    {
+        [Test]
+        public void When_no_schema_dbo_is_used_instead()
+        {
+            var sqlTable = SqlTable.Parse("Endpoint");
+
+            Assert.AreEqual("Endpoint", sqlTable.UnquotedName);
+            Assert.AreEqual("dbo", sqlTable.UnquotedSchema);
+        }
+
+        [Test]
+        public void When_no_catlog_specified_the_value_in_sqlTable_is_null()
+        {
+            var sqlTable = SqlTable.Parse("Endpoint@[some-schema]");
+
+            Assert.AreEqual("Endpoint", sqlTable.UnquotedName);
+            Assert.AreEqual(null, sqlTable.UnquotedCatalog);
+        }
+
+        [TestCase("Endpoint@[s]@[c]", "[Endpoint]", "[s]", "[c]")]
+        [TestCase("Endpo]int@[schema--x]@[D234F]", "[Endpo]]int]", "[schema--x]", "[D234F]")]
+        [TestCase("[Quoted]@[x]@[z]", "[Quoted]", "[x]", "[z]")]
+        public void Endptoint_name_schema_and_catalog_are_parsed_from_address_string_representation(string address, string endpoint, string schema, string catalog)
+        {
+            var sqlTable = SqlTable.Parse(address);
+
+            Assert.AreEqual(endpoint, sqlTable.QuotedName);
+            Assert.AreEqual(schema, sqlTable.QuotedSchema);
+            Assert.AreEqual(catalog, sqlTable.QuotedCatalog);
+        }
+    }
+}

--- a/src/ServiceControl.Transports.SQLServer/SqlTable.cs
+++ b/src/ServiceControl.Transports.SQLServer/SqlTable.cs
@@ -26,24 +26,15 @@
             return QuotedCatalog != null ? $"{QuotedCatalog}.{QuotedSchema}.{QuotedName}" : $"{QuotedSchema}.{QuotedName}";
         }
 
-        public static bool TryParse(string address, int pluginVersion, out SqlTable sqlTable)
+        public static SqlTable Parse(string address)
         {
             var parts = address.Split('@').ToArray();
 
-            if (pluginVersion == 1)
-            {
-                sqlTable = new SqlTable(parts[0], "dbo", null);
-                return true;
-            }
-
-            if (pluginVersion == 2 || pluginVersion == 3)
-            {
-                sqlTable = new SqlTable(parts[0], parts[1], parts[2]);
-                return true;
-            }
-
-            sqlTable = null;
-            return false;
+            return new SqlTable(
+                parts[0],
+                parts.Length > 1 ? parts[1] : "dbo",
+                parts.Length > 2 ? parts[2] : null
+            );
         }
 
         protected bool Equals(SqlTable other)


### PR DESCRIPTION
## Overview
Native Queue Length provider for SqlServer assumed that all endpoints running 3.* version of the transport will include both schema and catalog in addresses sent to monitoring instance. 

This is not true for versions [3.0 - 3.1.1) that do not support mulit-catalog feature.

## Solution
This PR changes the way SqlServer address is being parsed. It does not rely on endpoint major version anymore but does the parsing based on the available information sent in `LocalAddress` property.