### PR TITLE
SQL `QueueLenghtProvider` extracts custom schema information from connection string

### DIFF
--- a/src/ServiceControl.Monitoring.SmokeTests.SQLServer/Tests/SqlTableTests.cs
+++ b/src/ServiceControl.Monitoring.SmokeTests.SQLServer/Tests/SqlTableTests.cs
@@ -6,18 +6,18 @@
     public class SqlTableTests
     {
         [Test]
-        public void When_no_schema_dbo_is_used_instead()
+        public void When_no_schema_default_is_used_instead()
         {
-            var sqlTable = SqlTable.Parse("Endpoint");
+            var sqlTable = SqlTable.Parse("Endpoint", "dbo");
 
             Assert.AreEqual("Endpoint", sqlTable.UnquotedName);
             Assert.AreEqual("dbo", sqlTable.UnquotedSchema);
         }
 
         [Test]
-        public void When_no_catlog_specified_the_value_in_sqlTable_is_null()
+        public void When_no_catalog_specified_the_value_in_sqlTable_is_null()
         {
-            var sqlTable = SqlTable.Parse("Endpoint@[some-schema]");
+            var sqlTable = SqlTable.Parse("Endpoint@[some-schema]", "dbo");
 
             Assert.AreEqual("Endpoint", sqlTable.UnquotedName);
             Assert.AreEqual(null, sqlTable.UnquotedCatalog);
@@ -26,13 +26,21 @@
         [TestCase("Endpoint@[s]@[c]", "[Endpoint]", "[s]", "[c]")]
         [TestCase("Endpo]int@[schema--x]@[D234F]", "[Endpo]]int]", "[schema--x]", "[D234F]")]
         [TestCase("[Quoted]@[x]@[z]", "[Quoted]", "[x]", "[z]")]
-        public void Endptoint_name_schema_and_catalog_are_parsed_from_address_string_representation(string address, string endpoint, string schema, string catalog)
+        public void Endpoint_name_schema_and_catalog_are_parsed_from_address_string_representation(string address, string endpoint, string schema, string catalog)
         {
-            var sqlTable = SqlTable.Parse(address);
+            var sqlTable = SqlTable.Parse(address, "dbo");
 
             Assert.AreEqual(endpoint, sqlTable.QuotedName);
             Assert.AreEqual(schema, sqlTable.QuotedSchema);
             Assert.AreEqual(catalog, sqlTable.QuotedCatalog);
+        }
+
+        [Test]
+        public void Default_schema_is_used_if_none_is_specified_in_the_address()
+        {
+            var sqlTable = SqlTable.Parse("Endpoint", "custom-schema");
+
+            Assert.AreEqual(sqlTable.UnquotedSchema, "custom-schema");
         }
     }
 }

--- a/src/ServiceControl.Transports.SQLServer/ConnectionStringExtensions.cs
+++ b/src/ServiceControl.Transports.SQLServer/ConnectionStringExtensions.cs
@@ -1,0 +1,26 @@
+﻿namespace ServiceControl.Transports.SQLServer
+{
+    using System.Data.Common;
+
+    static class ConnectionStringExtensions
+    {
+        public static string RemoveCustomSchemaPart(this string connectionString, out string schema)
+        {
+            const string queueSchemaName = "Queue schema";
+
+            var builder = new DbConnectionStringBuilder
+            {
+                ConnectionString = connectionString
+            };
+
+            if (builder.TryGetValue(queueSchemaName, out var customSchema))
+            {
+                builder.Remove(queueSchemaName);
+            }
+
+            schema = (string)customSchema;
+
+            return builder.ConnectionString;
+        }
+    }
+}

--- a/src/ServiceControl.Transports.SQLServer/QueueLengthProvider.cs
+++ b/src/ServiceControl.Transports.SQLServer/QueueLengthProvider.cs
@@ -20,6 +20,7 @@
         ConcurrentDictionary<SqlTable, int> tableSizes = new ConcurrentDictionary<SqlTable, int>();
 
         string connectionString;
+        string defaultSchema;
         QueueLengthStore store;
 
         CancellationTokenSource stop = new CancellationTokenSource();
@@ -27,7 +28,10 @@
 
         public void Initialize(string connectionString, QueueLengthStore store)
         {
-            this.connectionString = connectionString;
+            this.connectionString = connectionString.RemoveCustomSchemaPart(out var customSchema);
+
+            defaultSchema = customSchema ?? "dbo";
+
             this.store = store;
         }
 
@@ -36,7 +40,7 @@
             var endpointInputQueue = new EndpointInputQueue(endpointInstanceId.EndpointName, metadataReport.LocalAddress);
             var localAddress = metadataReport.LocalAddress;
 
-            var sqlTable = SqlTable.Parse(localAddress);
+            var sqlTable = SqlTable.Parse(localAddress, defaultSchema);
             
             tableNames.AddOrUpdate(endpointInputQueue, _ => sqlTable, (_, currentSqlTable) =>
             {

--- a/src/ServiceControl.Transports.SQLServer/ServiceControl.Transports.SQLServer.csproj
+++ b/src/ServiceControl.Transports.SQLServer/ServiceControl.Transports.SQLServer.csproj
@@ -46,6 +46,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ConnectionStringExtensions.cs" />
     <Compile Include="InternalsVisibleTo.cs" />
     <Compile Include="QueueLengthProvider.cs" />
     <Compile Include="ServiceControlSQLServerTransport.cs" />

--- a/src/ServiceControl.Transports.SQLServer/ServiceControlSQLServerTransport.cs
+++ b/src/ServiceControl.Transports.SQLServer/ServiceControlSQLServerTransport.cs
@@ -1,6 +1,5 @@
 ﻿namespace ServiceControl.Transports.SQLServer
 {
-    using System.Data.Common;
     using NServiceBus;
     using NServiceBus.Settings;
     using NServiceBus.Transport;
@@ -9,26 +8,15 @@
     {
         public override TransportInfrastructure Initialize(SettingsHolder settings, string connectionString)
         {
-            const string queueSchemaName = "Queue schema";
+            connectionString = connectionString.RemoveCustomSchemaPart(out var customSchema);
 
-            var builder = new DbConnectionStringBuilder
+            if (customSchema != null)
             {
-                ConnectionString = connectionString
-            };
-
-            object customSchema;
-
-            if (builder.TryGetValue(queueSchemaName, out customSchema))
-            {
-                builder.Remove(queueSchemaName);
-
                 settings.Set("SqlServer.DisableConnectionStringValidation", true);
                 settings.Set("SqlServer.SchemaName", customSchema);
             }
 
-            return base.Initialize(settings, builder.ConnectionString);
+            return base.Initialize(settings, connectionString);
         }
-
-        
     }
 }

--- a/src/ServiceControl.Transports.SQLServer/SqlTable.cs
+++ b/src/ServiceControl.Transports.SQLServer/SqlTable.cs
@@ -26,13 +26,13 @@
             return QuotedCatalog != null ? $"{QuotedCatalog}.{QuotedSchema}.{QuotedName}" : $"{QuotedSchema}.{QuotedName}";
         }
 
-        public static SqlTable Parse(string address)
+        public static SqlTable Parse(string address, string defaultSchema)
         {
             var parts = address.Split('@').ToArray();
 
             return new SqlTable(
                 parts[0],
-                parts.Length > 1 ? parts[1] : "dbo",
+                parts.Length > 1 ? parts[1] : defaultSchema,
                 parts.Length > 2 ? parts[2] : null
             );
         }


### PR DESCRIPTION
## Problem
If a user specifies custom schema part in the connection string for the SQL Transport e.g. "Data Source=localhost\sqlexpress;Initial Catalog=nservicebus;pwd=<...>;uid=<...>;Queue Schema=nsb" the native `QueueLengthProvider` will fail.
This is caused by the fact that custom schema part is not removed and used before connection string value is passed to Ado .Net types.

## Solution
This PR makes sure that the custom schema part is extracted and used by the native queue length provider. 