### PR TITLE
Bump patch version of ASB and ASBS

### DIFF
--- a/src/ServiceControl.Monitoring.SmokeTests.AzureServiceBus/ServiceControl.Monitoring.SmokeTests.AzureServiceBus.csproj
+++ b/src/ServiceControl.Monitoring.SmokeTests.AzureServiceBus/ServiceControl.Monitoring.SmokeTests.AzureServiceBus.csproj
@@ -57,7 +57,7 @@
       <Version>3.0.2</Version>
     </PackageReference>
     <PackageReference Include="NServiceBus.Transport.AzureServiceBus">
-      <Version>1.0.0-alpha0164</Version>
+      <Version>1.0.0-alpha0172</Version>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
       <Version>11.0.2</Version>

--- a/src/ServiceControl.Monitoring.SmokeTests.LegacyAzureServiceBus/ServiceControl.Monitoring.SmokeTests.LegacyAzureServiceBus.csproj
+++ b/src/ServiceControl.Monitoring.SmokeTests.LegacyAzureServiceBus/ServiceControl.Monitoring.SmokeTests.LegacyAzureServiceBus.csproj
@@ -54,7 +54,7 @@
       <HintPath>..\packages\NServiceBus.AcceptanceTesting.7.1.4\lib\net452\NServiceBus.AcceptanceTesting.dll</HintPath>
     </Reference>
     <Reference Include="NServiceBus.Azure.Transports.WindowsAzureServiceBus, Version=8.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
-      <HintPath>..\packages\NServiceBus.Azure.Transports.WindowsAzureServiceBus.8.0.3\lib\net452\NServiceBus.Azure.Transports.WindowsAzureServiceBus.dll</HintPath>
+      <HintPath>..\packages\NServiceBus.Azure.Transports.WindowsAzureServiceBus.8.0.6\lib\net452\NServiceBus.Azure.Transports.WindowsAzureServiceBus.dll</HintPath>
     </Reference>
     <Reference Include="NServiceBus.Core, Version=7.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
       <HintPath>..\packages\NServiceBus.7.1.4\lib\net452\NServiceBus.Core.dll</HintPath>

--- a/src/ServiceControl.Monitoring.SmokeTests.LegacyAzureServiceBus/packages.config
+++ b/src/ServiceControl.Monitoring.SmokeTests.LegacyAzureServiceBus/packages.config
@@ -5,7 +5,7 @@
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net46" />
   <package id="NServiceBus" version="7.1.4" targetFramework="net46" />
   <package id="NServiceBus.AcceptanceTesting" version="7.1.4" targetFramework="net46" />
-  <package id="NServiceBus.Azure.Transports.WindowsAzureServiceBus" version="8.0.6" targetFramework="net461" />
+  <package id="NServiceBus.Azure.Transports.WindowsAzureServiceBus" version="8.0.6" targetFramework="net46" />
   <package id="NServiceBus.Metrics" version="3.0.0" targetFramework="net46" />
   <package id="NServiceBus.Metrics.ServiceControl" version="3.0.2" targetFramework="net46" />
   <package id="NServiceBus.Newtonsoft.Json" version="2.1.0" targetFramework="net46" />

--- a/src/ServiceControl.Monitoring.SmokeTests.LegacyAzureServiceBus/packages.config
+++ b/src/ServiceControl.Monitoring.SmokeTests.LegacyAzureServiceBus/packages.config
@@ -5,7 +5,7 @@
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net46" />
   <package id="NServiceBus" version="7.1.4" targetFramework="net46" />
   <package id="NServiceBus.AcceptanceTesting" version="7.1.4" targetFramework="net46" />
-  <package id="NServiceBus.Azure.Transports.WindowsAzureServiceBus" version="8.0.3" targetFramework="net46" />
+  <package id="NServiceBus.Azure.Transports.WindowsAzureServiceBus" version="8.0.6" targetFramework="net461" />
   <package id="NServiceBus.Metrics" version="3.0.0" targetFramework="net46" />
   <package id="NServiceBus.Metrics.ServiceControl" version="3.0.2" targetFramework="net46" />
   <package id="NServiceBus.Newtonsoft.Json" version="2.1.0" targetFramework="net46" />

--- a/src/ServiceControl.Transports.AzureServiceBus/ServiceControl.Transports.AzureServiceBus.csproj
+++ b/src/ServiceControl.Transports.AzureServiceBus/ServiceControl.Transports.AzureServiceBus.csproj
@@ -9,7 +9,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NServiceBus.Transport.AzureServiceBus" Version="1.0.0-alpha0164" />
+    <PackageReference Include="NServiceBus.Transport.AzureServiceBus" Version="1.0.0-alpha0172" />
   </ItemGroup>
 
 </Project>

--- a/src/ServiceControl.Transports.LegacyAzureServiceBus/ServiceControl.Transports.LegacyAzureServiceBus.csproj
+++ b/src/ServiceControl.Transports.LegacyAzureServiceBus/ServiceControl.Transports.LegacyAzureServiceBus.csproj
@@ -9,7 +9,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NServiceBus.Azure.Transports.WindowsAzureServiceBus" Version="8.0.3" />
+    <PackageReference Include="NServiceBus.Azure.Transports.WindowsAzureServiceBus" Version="8.0.6" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
I decided not to bump to ASB 9.x but just to 8.0.6 (latest patch version) because I figured for some reason we are still using 8.x which I don't know TBH