### PR TITLE
Update ASQ transport version 8.1.2

### DIFF
--- a/src/ServiceControl.Monitoring.SmokeTests.AzureStorageQueues/ServiceControl.Monitoring.SmokeTests.AzureStorageQueues.csproj
+++ b/src/ServiceControl.Monitoring.SmokeTests.AzureStorageQueues/ServiceControl.Monitoring.SmokeTests.AzureStorageQueues.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\packages\NUnit.3.10.1\build\NUnit.props" Condition="Exists('..\packages\NUnit.3.10.1\build\NUnit.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
@@ -57,7 +57,7 @@
       <HintPath>..\packages\NServiceBus.AcceptanceTesting.7.1.6\lib\net452\NServiceBus.AcceptanceTesting.dll</HintPath>
     </Reference>
     <Reference Include="NServiceBus.Azure.Transports.WindowsAzureStorageQueues, Version=8.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
-      <HintPath>..\packages\NServiceBus.Azure.Transports.WindowsAzureStorageQueues.8.1.0\lib\net452\NServiceBus.Azure.Transports.WindowsAzureStorageQueues.dll</HintPath>
+      <HintPath>..\packages\NServiceBus.Azure.Transports.WindowsAzureStorageQueues.8.1.2\lib\net452\NServiceBus.Azure.Transports.WindowsAzureStorageQueues.dll</HintPath>
     </Reference>
     <Reference Include="NServiceBus.Core, Version=7.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
       <HintPath>..\packages\NServiceBus.7.1.6\lib\net452\NServiceBus.Core.dll</HintPath>

--- a/src/ServiceControl.Monitoring.SmokeTests.AzureStorageQueues/packages.config
+++ b/src/ServiceControl.Monitoring.SmokeTests.AzureStorageQueues/packages.config
@@ -7,7 +7,7 @@
   <package id="Newtonsoft.Json" version="12.0.1" targetFramework="net461" />
   <package id="NServiceBus" version="7.1.6" targetFramework="net461" />
   <package id="NServiceBus.AcceptanceTesting" version="7.1.6" targetFramework="net461" />
-  <package id="NServiceBus.Azure.Transports.WindowsAzureStorageQueues" version="8.1.0" targetFramework="net461" />
+  <package id="NServiceBus.Azure.Transports.WindowsAzureStorageQueues" version="8.1.2" targetFramework="net461" />
   <package id="NServiceBus.Metrics" version="3.0.0" targetFramework="net46" />
   <package id="NServiceBus.Metrics.ServiceControl" version="3.0.2" targetFramework="net46" />
   <package id="NServiceBus.Newtonsoft.Json" version="2.2.0" targetFramework="net461" />

--- a/src/ServiceControl.Transports.AzureStorageQueues/ServiceControl.Transports.AzureStorageQueues.csproj
+++ b/src/ServiceControl.Transports.AzureStorageQueues/ServiceControl.Transports.AzureStorageQueues.csproj
@@ -49,7 +49,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.Azure.Transports.WindowsAzureStorageQueues">
-      <Version>8.1.1</Version>
       <Version>8.1.2</Version>
     </PackageReference>
   </ItemGroup>

--- a/src/ServiceControl.Transports.AzureStorageQueues/ServiceControl.Transports.AzureStorageQueues.csproj
+++ b/src/ServiceControl.Transports.AzureStorageQueues/ServiceControl.Transports.AzureStorageQueues.csproj
@@ -50,6 +50,7 @@
   <ItemGroup>
     <PackageReference Include="NServiceBus.Azure.Transports.WindowsAzureStorageQueues">
       <Version>8.1.1</Version>
+      <Version>8.1.2</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
This PR updates ASQ transport to the [8.1.2](https://github.com/Particular/NServiceBus.AzureStorageQueues/releases/tag/8.1.1) patch. This prevents the transport from over-fetching and causing peek lease timeouts in monitoring instance.