### PR TITLE
Fix excessive queue length querying in ASQ

### DIFF
--- a/src/ServiceControl.Transports.AzureStorageQueues/QueueLengthProvider.cs
+++ b/src/ServiceControl.Transports.AzureStorageQueues/QueueLengthProvider.cs
@@ -16,9 +16,8 @@
 
     public class QueueLengthProvider : IProvideQueueLength
     {
-        ConcurrentDictionary<EndpointInputQueue, CloudQueue> queues = new ConcurrentDictionary<EndpointInputQueue, CloudQueue>();
-        ConcurrentDictionary<CloudQueue, int> sizes = new ConcurrentDictionary<CloudQueue, int>();
-        ConcurrentDictionary<CloudQueue, CloudQueue> problematicQueues = new ConcurrentDictionary<CloudQueue, CloudQueue>();
+        ConcurrentDictionary<EndpointInputQueue, QueueLengthValue> queueLengths = new ConcurrentDictionary<EndpointInputQueue, QueueLengthValue>();
+        ConcurrentDictionary<string, string> problematicQueuesNames = new ConcurrentDictionary<string, string>();
 
         string connectionString;
         QueueLengthStore store;
@@ -38,19 +37,23 @@
             var queueName = QueueNameSanitizer.Sanitize(metadataReport.LocalAddress);
 
             var queueClient = CloudStorageAccount.Parse(connectionString).CreateCloudQueueClient();
-            var queue = queueClient.GetQueueReference(queueName);
 
-            queues.AddOrUpdate(endpointInputQueue, _ => queue, (_, currentQueue) =>
+            var queueLength = new QueueLengthValue
             {
-                if (currentQueue.Name.Equals(queue.Name) == false)
+                QueueName = queueName,
+                Length = 0,
+                QueueReference = queueClient.GetQueueReference(queueName)
+            };
+
+            queueLengths.AddOrUpdate(endpointInputQueue, _ => queueLength, (_, currentLength) =>
+            {
+                if (currentLength.QueueName.Equals(queueLength.QueueName))
                 {
-                    sizes.TryRemove(currentQueue, out var _);
+                    return currentLength;
                 }
 
-                return queue;
+                return queueLength;
             });
-
-            sizes.TryAdd(queue, 0);
         }
 
         public void Process(EndpointInstanceId endpointInstanceId, TaggedLongValueOccurrence metricsReport)
@@ -100,28 +103,31 @@
         {
             var nowTicks = DateTime.UtcNow.Ticks;
 
-            foreach (var tableNamePair in queues)
+            foreach (var endpointQueueLengthPair in queueLengths)
             {
-                store.Store(
-                    new[]{ new RawMessage.Entry
-                    {
-                        DateTicks = nowTicks,
-                        Value = sizes.TryGetValue(tableNamePair.Value, out var size) ? size : 0
-                    }},
-                    tableNamePair.Key);
+                var queueLengthEntry = new RawMessage.Entry
+                {
+                    DateTicks = nowTicks,
+                    Value = endpointQueueLengthPair.Value.Length
+                };
+
+                store.Store(new[]{ queueLengthEntry }, endpointQueueLengthPair.Key);
             }
         }
 
-        Task FetchQueueSizes(CancellationToken token) => Task.WhenAll(sizes.Select(kvp => FetchLength(kvp.Key, token)));
+        Task FetchQueueSizes(CancellationToken token) => Task.WhenAll(queueLengths.Select(kvp => FetchLength(kvp.Value, token)));
 
-        async Task FetchLength(CloudQueue queue, CancellationToken token)
+        async Task FetchLength(QueueLengthValue queueLength, CancellationToken token)
         {
             try
             {
-                await queue.FetchAttributesAsync(token).ConfigureAwait(false);
-                sizes[queue] = queue.ApproximateMessageCount.GetValueOrDefault();
+                var queueReference = queueLength.QueueReference;
 
-                problematicQueues.TryRemove(queue, out _);
+                await queueReference.FetchAttributesAsync(token).ConfigureAwait(false);
+
+                queueLength.Length = queueReference.ApproximateMessageCount.GetValueOrDefault();
+
+                problematicQueuesNames.TryRemove(queueLength.QueueName, out _);
             }
             catch (OperationCanceledException)
             {
@@ -130,11 +136,18 @@
             catch (Exception ex)
             {
                 // simple "log once" approach to do not flood logs
-                if (problematicQueues.TryAdd(queue, queue))
+                if (problematicQueuesNames.TryAdd(queueLength.QueueName, queueLength.QueueName))
                 {
-                    Logger.Error($"Obtaining Azure Storage Queue count failed for '{queue.Name}'", ex);
+                    Logger.Error($"Obtaining Azure Storage Queue count failed for '{queueLength.QueueName}'", ex);
                 }
             }
+        }
+
+        class QueueLengthValue
+        {
+            public string QueueName;
+            public volatile int Length;
+            public CloudQueue QueueReference;
         }
 
         static TimeSpan QueryDelayInterval = TimeSpan.FromMilliseconds(200);

--- a/src/ServiceControl.Transports.AzureStorageQueues/QueueLengthProvider.cs
+++ b/src/ServiceControl.Transports.AzureStorageQueues/QueueLengthProvider.cs
@@ -38,22 +38,14 @@
 
             var queueClient = CloudStorageAccount.Parse(connectionString).CreateCloudQueueClient();
 
-            var queueLength = new QueueLengthValue
+            var emptyQueueLength = new QueueLengthValue
             {
                 QueueName = queueName,
                 Length = 0,
                 QueueReference = queueClient.GetQueueReference(queueName)
             };
 
-            queueLengths.AddOrUpdate(endpointInputQueue, _ => queueLength, (_, currentLength) =>
-            {
-                if (currentLength.QueueName.Equals(queueLength.QueueName))
-                {
-                    return currentLength;
-                }
-
-                return queueLength;
-            });
+            queueLengths.AddOrUpdate(endpointInputQueue, _ => emptyQueueLength, (_, existingQueueLength) => existingQueueLength);
         }
 
         public void Process(EndpointInstanceId endpointInstanceId, TaggedLongValueOccurrence metricsReport)


### PR DESCRIPTION
### Description
Before this fix the `size` collection in the `NativeQueueLength` would grow one entry for each monitoring report received. This, in turn, resulted in excessive storage account usage due to the growing number of queue length queries.

### Fix
This PR introduces a dedicated class that stores all queue length related variables. This enables having only a single collection for queue length data which helps ensuring that the state of the `NativeQueueLength` does not grow indefinitely.