### PR TITLE
Remove API quota to allow serving large collections of message types

### DIFF
--- a/src/ServiceControl.Monitoring/Http/HttpEndpoint.cs
+++ b/src/ServiceControl.Monitoring/Http/HttpEndpoint.cs
@@ -7,6 +7,7 @@ namespace ServiceControl.Monitoring.Http
 {
     using System;
     using Autofac;
+    using Nancy.Bootstrapper;
     using Nancy.Bootstrappers.Autofac;
 
     class HttpEndpoint : Feature
@@ -64,6 +65,13 @@ namespace ServiceControl.Monitoring.Http
         class Bootstrapper : AutofacNancyBootstrapper
         {
             readonly ILifetimeScope lifetimeScope;
+
+            protected override void ApplicationStartup(ILifetimeScope container, IPipelines pipelines)
+            {
+                Nancy.Json.JsonSettings.MaxJsonLength = int.MaxValue;
+
+                base.ApplicationStartup(container, pipelines);
+            }
 
             public Bootstrapper(ILifetimeScope lifetimeScope)
             {


### PR DESCRIPTION
## Overview
Some of our clients have a lot of message types flowing through single logic instances e.g. 600+. This PR removes quota at Nacy level to make sure that big responses are not truncated and can be properly served to the ServicePulse instances.