### PR TITLE
Bump ASBS transport version

### DIFF
--- a/src/ServiceControl.Transports.AzureServiceBus/ServiceControl.Transports.AzureServiceBus.csproj
+++ b/src/ServiceControl.Transports.AzureServiceBus/ServiceControl.Transports.AzureServiceBus.csproj
@@ -9,7 +9,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NServiceBus.Transport.AzureServiceBus" Version="1.1.1" />
+    <PackageReference Include="NServiceBus.Transport.AzureServiceBus" Version="1.2.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Update ASBS transport with the bug fix for `MessageLockLostException` that causes SC to shutdown (https://github.com/Particular/NServiceBus.Transport.AzureServiceBus/issues/70).